### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@main
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: julienkeiff/docker-registry/feed_tech_server
         username: ${{ secrets.DOCKER_HUB_USER }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore